### PR TITLE
Update Wauh version in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.gecko</groupId>
     <artifactId>Wauh</artifactId>
-    <version>4.5.0</version>
+    <version>5.0.0</version>
     <packaging>jar</packaging>
 
     <name>Wauh</name>


### PR DESCRIPTION
The version of the artifact 'Wauh' in pom.xml has been updated. It has been upgraded from version 4.5.0 to version 5.0.0. This version update indicates significant changes or improvements in the project.
