### PR TITLE
Add operator permissions to plugin.yml and update version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.gecko</groupId>
     <artifactId>Wauh</artifactId>
-    <version>5.2.0</version>
+    <version>5.3.0</version>
     <packaging>jar</packaging>
 
     <name>wauh</name>

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -6,12 +6,20 @@ commands:
   stopwauh:
     description: Stop removing the wauh
     usage: /stopwauhremoval
+    permission: op
+    permission-message: §cYou need to have operator permissions to run this command!
   setradiuslimit:
     description: Set the radius limit
     usage: /setradiuslimit <radius>
+    permission: op
+    permission-message: §cYou need to have operator permissions to run this command!
   toggleremovalview:
     description: Toggle the visibility of the removal
     usage: /toggleremovalview
+    permission: op
+    permission-message: §cYou need to have operator permissions to run this command!
   test:
     description: test gui
     usage: /test
+    permission: op
+    permission-message: §cYou need to have operator permissions to run this command!


### PR DESCRIPTION
The commit includes addition of operator permissions for various commands in the plugin.yml file. This ensures that these commands can only be run by operators. In addition, the project version in pom.xml has been updated from 5.2.0 to 5.3.0.
