### PR TITLE
Updated TNT behavior and added explosion flag in BedrockListener

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.gecko</groupId>
     <artifactId>Wauh</artifactId>
-    <version>5.2.0</version>
+    <version>5.4.0</version>
     <packaging>jar</packaging>
 
     <name>wauh</name>


### PR DESCRIPTION
The code now has TNT blocks primed before explosion, enhancing gameplay and interactive aspects within the BedrockListener. An 'explosionTrigger' flag was incorporated to adjust certain functions when an explosion is currently active.
